### PR TITLE
Added command line options

### DIFF
--- a/KinectV2OpenTrack/HeadTracker.cs
+++ b/KinectV2OpenTrack/HeadTracker.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Kinect;
 using Microsoft.Kinect.Face;
+using static KinectV2OpenTrack.Program;
 
 namespace KinectV2OpenTrack
 {
@@ -27,15 +28,12 @@ namespace KinectV2OpenTrack
         private bool lastSensorAvail = false;
         private bool tracking = false;
 
-
-        private const int port = 4242;
-        private const string ip = "127.0.0.1";
         private Socket socket;
         private IPAddress dest;
         private IPEndPoint endPoint;
         private byte[] sendBuffer;
 
-        public void InitTracker()
+        public void InitTracker(Options o)
         {
             lastSensorAvail = false;
             sensor = KinectSensor.GetDefault();
@@ -53,12 +51,12 @@ namespace KinectV2OpenTrack
             sensor.IsAvailableChanged += SensorAvailableChanged;
             Console.WriteLine("Face tracker ready.");
             
-            dest = IPAddress.Parse(ip);
-            endPoint = new IPEndPoint(dest, port);
+            dest = IPAddress.Parse(o.Ip);
+            endPoint = new IPEndPoint(dest, o.Port);
             
             sendBuffer = new byte[48];
 
-            Console.WriteLine("UDP Socket created for port {0}", port);
+            Console.WriteLine("UDP Socket created for host {0}, port {1}", o.Ip, o.Port);
         }
 
 

--- a/KinectV2OpenTrack/KinectV2OpenTrack.csproj
+++ b/KinectV2OpenTrack/KinectV2OpenTrack.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Kinect, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Kinect.Face, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64" />
     <Reference Include="System" />
@@ -141,6 +144,7 @@
     <None Include="NuiDatabase\HDFaceTracker\WholeHeadModel\fullMeanHead60_tri.ply">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="NuiDatabase\HDFaceTracker\AAMModel\Map2D3D_F.txt">

--- a/KinectV2OpenTrack/Program.cs
+++ b/KinectV2OpenTrack/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CommandLine;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,11 +10,24 @@ namespace KinectV2OpenTrack
 {
     class Program
     {
+        public class Options
+        {
+            [Option('i', "ip", Required = false, Default = "127.0.0.1", HelpText = "Ip address of the computer running OpenTrack")]
+            public string Ip { get; set; }
+
+            [Option('p', "port", Required = false, Default = 4242, HelpText = "Port the OpenTrack instance is listening on")]
+            public int Port { get; set; }
+        }
+
         static void Main(string[] args)
         {
-            HeadTracker tracker = new HeadTracker();
-            tracker.InitTracker();
-            tracker.StartTracking();
+            Parser.Default.ParseArguments<Options>(args)
+                .WithParsed<Options>(o =>
+                {
+                    HeadTracker tracker = new HeadTracker();
+                    tracker.InitTracker(o);
+                    tracker.StartTracking();
+                });
         }
     }
 }

--- a/KinectV2OpenTrack/packages.config
+++ b/KinectV2OpenTrack/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="2.8.0" targetFramework="net471" />
+</packages>


### PR DESCRIPTION
Allow users to specify the ip address and port of the computer running opentrack instead of assuming localhost